### PR TITLE
feat(marquez-api): Support fileset and model version dataset type

### DIFF
--- a/api/src/main/java/marquez/api/models/Metadata.java
+++ b/api/src/main/java/marquez/api/models/Metadata.java
@@ -27,6 +27,7 @@ import lombok.NonNull;
 import lombok.ToString;
 import marquez.api.exceptions.FacetNotValid;
 import marquez.common.Utils;
+import marquez.common.gravitino.GravitinoUtils;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetType;

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -438,7 +438,7 @@ public final class Utils {
 
       DatasetVersionData.DatasetVersionDataBuilder datasetMeta(DatasetMeta datasetMeta) {
         if (datasetMeta == null) return this;
-        return datasetMeta.getType().equals(DB_TABLE)
+        return datasetMeta.getType().isNotStream()
             ? dbTableMeta((DbTableMeta) datasetMeta)
             : streamMeta((StreamMeta) datasetMeta);
       }

--- a/api/src/main/java/marquez/common/gravitino/GravitinoUtils.java
+++ b/api/src/main/java/marquez/common/gravitino/GravitinoUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package marquez.common.gravitino;
+
+import java.util.Map;
+import marquez.common.models.DatasetType;
+import marquez.service.models.LineageEvent;
+
+
+public class GravitinoUtils {
+
+  private static final String DATASET_TYPE_FACET_NAME = "datasetType";
+  private static final String DATASET_TYPE_KEY_NAME = "datasetType";
+
+  public static DatasetType getDatasetType(LineageEvent.Dataset dataset) throws Exception {
+    Map<String, Object> facets = dataset.getFacets().getAdditionalFacets();
+    if (facets == null || !facets.containsKey(DATASET_TYPE_FACET_NAME)) {
+      return DatasetType.DB_TABLE;
+    }
+
+    Object object = facets.get(DATASET_TYPE_FACET_NAME);
+    if (!(object instanceof Map)) {
+      return DatasetType.DB_TABLE;
+    }
+
+    Map<String, String> datatypeFacets = (Map<String, String>) object;
+    String type = datatypeFacets.getOrDefault(DATASET_TYPE_KEY_NAME, DatasetType.DB_TABLE.toString());
+    return DatasetType.valueOf(type.toUpperCase());
+  }
+}

--- a/api/src/main/java/marquez/common/models/DatasetType.java
+++ b/api/src/main/java/marquez/common/models/DatasetType.java
@@ -7,5 +7,13 @@ package marquez.common.models;
 
 public enum DatasetType {
   DB_TABLE,
-  STREAM;
+  STREAM,
+  FILESET,
+  MODEL_VERSION;
+
+  // Marquez only support DBTable and Stream for the dataset, we place FILESET and MODEL_VERSION to
+  // DBTable too.
+  public boolean isNotStream() {
+    return !this.equals(STREAM);
+  }
 }

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import marquez.common.Utils;
+import marquez.common.gravitino.GravitinoUtils;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetType;
@@ -1097,7 +1098,11 @@ public interface OpenLineageDao extends BaseDao {
   }
 
   default DatasetType getDatasetType(Dataset ds) {
-    return DatasetType.DB_TABLE;
+    try {
+      return GravitinoUtils.getDatasetType(ds);
+    } catch (Exception e) {
+      return DatasetType.DB_TABLE;
+    }
   }
 
   default RunState getRunState(String eventType) {

--- a/api/src/main/java/marquez/db/mappers/DatasetMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetMapper.java
@@ -53,7 +53,7 @@ public final class DatasetMapper implements RowMapper<Dataset> {
       throws SQLException {
     DatasetType type = DatasetType.valueOf(stringOrThrow(results, Columns.TYPE));
 
-    if (type == DatasetType.DB_TABLE) {
+    if (type.isNotStream()) {
       return new DbTable(
           new DatasetId(
               NamespaceName.of(stringOrThrow(results, Columns.NAMESPACE_NAME)),
@@ -63,6 +63,7 @@ public final class DatasetMapper implements RowMapper<Dataset> {
           timestampOrThrow(results, Columns.CREATED_AT),
           timestampOrThrow(results, Columns.UPDATED_AT),
           SourceName.of(stringOrThrow(results, Columns.SOURCE_NAME)),
+          type,
           toFields(results, "fields"),
           toTags(results, "tags"),
           timestampOrNull(results, Columns.LAST_MODIFIED_AT),

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
@@ -43,7 +43,7 @@ public final class DatasetVersionMapper implements RowMapper<DatasetVersion> {
 
     DatasetType type = DatasetType.valueOf(stringOrThrow(results, Columns.TYPE));
     DatasetVersion datasetVersion;
-    if (type == DatasetType.DB_TABLE) {
+    if (type.isNotStream()) {
       datasetVersion =
           new DbTableVersion(
               new DatasetId(
@@ -54,6 +54,7 @@ public final class DatasetVersionMapper implements RowMapper<DatasetVersion> {
               timestampOrThrow(results, Columns.CREATED_AT),
               Version.of(uuidOrThrow(results, Columns.CURRENT_VERSION_UUID)),
               SourceName.of(stringOrThrow(results, Columns.SOURCE_NAME)),
+              type,
               toFields(results, "fields"),
               columnNames.contains("tags") ? toTags(results, "tags") : null,
               stringOrNull(results, Columns.DESCRIPTION),

--- a/api/src/main/java/marquez/service/models/DbTable.java
+++ b/api/src/main/java/marquez/service/models/DbTable.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
+import marquez.common.models.DatasetType;
 import marquez.common.models.Field;
 import marquez.common.models.SourceName;
 import marquez.common.models.TagName;
@@ -31,6 +32,7 @@ public final class DbTable extends Dataset {
       final Instant createdAt,
       final Instant updatedAt,
       final SourceName sourceName,
+      final DatasetType datasetType,
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final Instant lastModifiedAt,
@@ -41,7 +43,7 @@ public final class DbTable extends Dataset {
       final boolean isDeleted) {
     super(
         id,
-        DB_TABLE,
+        datasetType,
         name,
         physicalName,
         createdAt,

--- a/api/src/main/java/marquez/service/models/DbTableVersion.java
+++ b/api/src/main/java/marquez/service/models/DbTableVersion.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
+import marquez.common.models.DatasetType;
 import marquez.common.models.Field;
 import marquez.common.models.SourceName;
 import marquez.common.models.TagName;
@@ -32,6 +33,7 @@ public final class DbTableVersion extends DatasetVersion {
       final Instant createdAt,
       final Version version,
       final SourceName sourceName,
+      final DatasetType datasetType,
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final String description,
@@ -41,7 +43,7 @@ public final class DbTableVersion extends DatasetVersion {
       @Nullable final ImmutableMap<String, Object> facets) {
     super(
         id,
-        DB_TABLE,
+        datasetType,
         name,
         physicalName,
         createdAt,


### PR DESCRIPTION
### Problem

Marquez only support DB_TABLE and STREAM dataset type, we add fileset and model version dataset type support in this PR
